### PR TITLE
Fix events called on activeControls array

### DIFF
--- a/src/control/cad.js
+++ b/src/control/cad.js
@@ -153,8 +153,8 @@ class CadControl extends Control {
       const pos = e.target.getArray().indexOf(this.snapInteraction);
 
       if (this.snapInteraction.getActive() && pos > -1 && pos !== e.target.getLength() - 1) {
-        this.deactivate();
-        this.activate();
+        this.deactivate(true);
+        this.activate(true);
       }
       // eslint-disable-next-line no-extra-bind
     }).bind(this));
@@ -357,8 +357,8 @@ class CadControl extends Control {
   /**
    * @inheritdoc
    */
-  activate() {
-    super.activate();
+  activate(silent) {
+    super.activate(silent);
     this.snapLayer.setMap(this.map);
     this.linesLayer.setMap(this.map);
     this.map.addInteraction(this.pointerInteraction);

--- a/src/control/control.js
+++ b/src/control/control.js
@@ -140,14 +140,18 @@ class Control extends ol.control.Control {
   /**
    * Activate the control
    */
-  activate() {
+  activate(silent) {
     this.active = true;
     this.element.className += ' active';
-    this.dispatchEvent({
-      type: 'change:active',
-      target: this,
-      detail: { control: this },
-    });
+
+    if (!silent) {
+      this.dispatchEvent({
+        type: 'change:active',
+        target: this,
+        detail: { control: this },
+      });
+    }
+
     this.openDialog();
   }
 

--- a/src/editor.js
+++ b/src/editor.js
@@ -150,19 +150,22 @@ class Editor {
    * @private
    */
   activeStateChange(ctrl) {
-    // deactivate other controls that are not standalone
+    // Deactivate other controls that are not standalone
     if (ctrl.getActive() && ctrl.standalone) {
       for (let i = 0; i < this.controls.getLength(); i += 1) {
-        if ((this.controls.item(i) !== ctrl) &&
-          (this.controls.item(i).standalone)) {
-          this.controls.item(i).deactivate();
+        const otherCtrl = this.controls.item(i);
+        if (otherCtrl !== ctrl && otherCtrl.getActive() && otherCtrl.standalone) {
+          otherCtrl.deactivate();
+          this.activeControls.remove(otherCtrl);
         }
       }
     }
 
-    const ctrls = this.controls.getArray().filter(c => c.getActive());
-    this.activeControls.clear();
-    this.activeControls.extend(ctrls);
+    if (ctrl.getActive()) {
+      this.activeControls.push(ctrl);
+    } else {
+      this.activeControls.remove(ctrl);
+    }
   }
 }
 


### PR DESCRIPTION
On activation/deactivation of a tool the Collection events 'add/remove' were triggered more than necessary (x10) 