### PR TITLE
Label controls

### DIFF
--- a/img/draw_label.svg
+++ b/img/draw_label.svg
@@ -1,0 +1,80 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   width="454.681"
+   height="120mm"
+   viewBox="0 0 426.264 425.197"
+   version="1.1"
+   id="svg14"
+   sodipodi:docname="draw_label.svg"
+   inkscape:version="0.92.4 (5da689c313, 2019-01-14)">
+  <metadata
+     id="metadata20">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title></dc:title>
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <defs
+     id="defs18" />
+  <sodipodi:namedview
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1"
+     objecttolerance="10"
+     gridtolerance="10"
+     guidetolerance="10"
+     inkscape:pageopacity="0"
+     inkscape:pageshadow="2"
+     inkscape:window-width="1920"
+     inkscape:window-height="1017"
+     id="namedview16"
+     showgrid="false"
+     inkscape:zoom="0.52034722"
+     inkscape:cx="227.3405"
+     inkscape:cy="226.77165"
+     inkscape:window-x="-8"
+     inkscape:window-y="-8"
+     inkscape:window-maximized="1"
+     inkscape:current-layer="svg14" />
+  <g
+     transform="translate(-163.736 -357.276)"
+     id="g12">
+    <path
+       d="M530 657.362v120"
+       fill="none"
+       stroke="#000"
+       stroke-width="30"
+       stroke-linejoin="round"
+       id="path2" />
+    <path
+       d="M470 717.362h120"
+       fill="none"
+       stroke="#000"
+       stroke-width="30"
+       stroke-linejoin="round"
+       id="path6" />
+  </g>
+  <text
+     xml:space="preserve"
+     style="font-style:normal;font-weight:normal;font-size:118.21729279px;line-height:1.25;font-family:sans-serif;letter-spacing:0px;word-spacing:0px;fill:#000000;fill-opacity:1;stroke:none;stroke-width:2.95543218"
+     x="24.508337"
+     y="235.40814"
+     id="text1394"><tspan
+       sodipodi:role="line"
+       id="tspan1392"
+       x="24.508337"
+       y="235.40814"
+       style="stroke-width:2.95543218">LABEL</tspan></text>
+</svg>

--- a/src/control/index.js
+++ b/src/control/index.js
@@ -7,6 +7,7 @@ import Buffer from './buffer';
 import Union from './union';
 import Intersection from './intersection';
 import Difference from './difference';
+import Label from './label';
 
 export {
   Control,
@@ -18,4 +19,5 @@ export {
   Union,
   Intersection,
   Difference,
+  Label,
 };

--- a/src/control/label.js
+++ b/src/control/label.js
@@ -1,0 +1,107 @@
+import { Draw } from 'ol/interaction';
+import { Style, Text } from 'ol/style';
+import Control from './control';
+import Constants from '../helper/constants';
+import drawLabelSVG from '../../img/draw_label.svg';
+
+/**
+ * Control for drawing label features.
+ * @extends {ole.Control}
+ * @alias ole.DrawControl
+ */
+class LabelControl extends Control {
+  /**
+   * @param {Object} [options] Tool options.
+   * @param {Style.StyleLike} [options.style] Style used for the draw interaction.
+   */
+  constructor(options) {
+    super(Object.assign({
+      title: 'Label',
+      className: 'ole-control-draw',
+      image: drawLabelSVG,
+      defaultLabelText: 'New label',
+      text: '',
+    }, options));
+
+
+    /**
+     * @type {ol.interaction.Draw}
+     * @private
+     */
+    this.labelInteraction = new Draw({
+      type: 'Point',
+      features: options.features,
+      source: options.source,
+      style: () =>
+        new Style({
+          text: new Text({
+            text: this.getLabelText(),
+            zIndex: Infinity,
+            font: '14px sans-serif',
+          }),
+        }),
+      stopClick: true,
+    });
+
+    /**
+   * Computes the text to be set on the label feature.
+   * @private
+   */
+    this.getLabelText = () =>
+      this.properties.text || this.properties.defaultLabelText;
+
+    /**
+     * @callback drawEndCallback
+     * @param {event} [event]
+     * @private
+     */
+    this.drawEndCallback = (event) => {
+      event.feature.set(Constants.LABEL_PROP_NAME, this.getLabelText());
+      options.source.changed();
+    };
+  }
+
+  /**
+   * @inheritdoc
+   */
+  getDialogTemplate() {
+    return `
+        <label>Label text: &nbsp;
+        <input type="text" id="label-text"
+            value="${this.properties.text}"
+        />
+        </label>
+        <input type="button" value="OK" id="label-text-btn" />
+    `;
+  }
+
+  /**
+   * @inheritdoc
+   */
+  activate() {
+    super.activate();
+    document.getElementById('label-text-btn').addEventListener('click', () => {
+      const input = document.getElementById('label-text');
+      this.setProperties({ text: input.value });
+      // keep the focus in the input control
+      input.focus();
+    });
+
+    document.getElementById('label-text').focus();
+
+    this.labelInteraction.on('drawend', this.drawEndCallback);
+    this.map.addInteraction(this.labelInteraction);
+  }
+
+  /**
+     * @inheritdoc
+   */
+  deactivate(silent) {
+    this.setProperties({ text: '' });
+    this.labelInteraction.un('drawend', this.drawEndCallback);
+    this.map.removeInteraction(this.labelInteraction);
+    super.deactivate(silent);
+  }
+}
+
+export default LabelControl;

--- a/src/control/rotate.js
+++ b/src/control/rotate.js
@@ -6,6 +6,7 @@ import Pointer from 'ol/interaction/Pointer';
 import Control from './control';
 import rotateSVG from '../../img/rotate.svg';
 import rotateMapSVG from '../../img/rotate_map.svg';
+import Constants from '../helper/constants';
 
 /**
  * Tool with for rotating geometries.
@@ -117,9 +118,11 @@ class RotateControl extends Control {
 
       const rotationDiff = this.initialRotation - rotation;
       const geomRotation = rotationDiff - this.feature.get(this.rotateAttribute);
-
-      this.feature.getGeometry().rotate(-geomRotation, this.center);
-      this.rotateFeature.getGeometry().rotate(-geomRotation, this.center);
+      if (!this.feature.get(Constants.LABEL_PROP_NAME)) {
+        // The label feature is actually a point.
+        this.feature.getGeometry().rotate(-geomRotation, this.center);
+        this.rotateFeature.getGeometry().rotate(-geomRotation, this.center);
+      }
 
       this.feature.set(this.rotateAttribute, rotationDiff);
       this.rotateFeature.set(this.rotateAttribute, rotationDiff);

--- a/src/helper/constants.js
+++ b/src/helper/constants.js
@@ -1,0 +1,3 @@
+export default class Constants {
+  static get LABEL_PROP_NAME() { return '__LABEL'; }
+}

--- a/src/index.html
+++ b/src/index.html
@@ -1,4 +1,4 @@
-<html>
+﻿<html>
   <head>
     <title>OpenLayers Editor</title>
     <meta charset="utf-8" />
@@ -14,11 +14,31 @@
     <script src="index.js"></script>
     <div id="map"></div>
     <script type="text/javascript">
+        
+      var createLabelStyle = (labelTextOptions, defaultStyle) => {
+        return (feature, resolution) => {
+          if (feature.get(ole.constants.LABEL_PROP_NAME)) {
+            const rotation = (labelTextOptions.rotation || 0) + (feature.get('ole_rotation') || 0);
+            return new ol.style.Style({
+              text: new ol.style.Text({ font: '14px sans-serif', text: feature.get(ole.constants.LABEL_PROP_NAME), rotation }),
+            });
+          } else if (defaultStyle) {
+            if (typeof defaultStyle === 'function') { 
+              return defaultStyle(feature, resolution); 
+            }
+            return defaultStyle;
+          }
+          return new Vector().getStyleFunction()();
+        };
+      }
+
       var editLayer = new ol.layer.Vector({
         source: new ol.source.Vector({
           wrapX: false
-        })
+        }),
+        style: createLabelStyle({ font: '14px sans-serif'})
       });
+    
       const PROJECTION = ol.proj.get("EPSG:3857");
       const PROJECTION_EXTENT = PROJECTION.getExtent();
 
@@ -109,6 +129,11 @@
         source: editLayer.getSource()
       });
 
+      var drawLabel = new ole.control.Label({
+        type: "Label",
+        source: editLayer.getSource()
+      });
+
       var rotate = new ole.control.Rotate({
         source: editLayer.getSource()
       });
@@ -141,6 +166,7 @@
       editor.addControls([
         cad,
         draw,
+        drawLabel,
         drawLine,
         drawPoly,
         modify,

--- a/src/index.js
+++ b/src/index.js
@@ -2,5 +2,6 @@ import Editor from './editor';
 import * as control from './control';
 import * as service from './service';
 import * as interaction from './interaction';
+import constants from './helper/constants';
 
-export { control, service, interaction, Editor };
+export { control, service, interaction, constants, Editor };


### PR DESCRIPTION
There is only one control added, the `Label` control. Adding, moving, editing and rotating functionalities are implemented using the current infrastructure. 

**What's missing**
- A style for the selected label

**What can be improved**
- The `modify` implementation.

Since the label is actually a point with a text style, differentiating between `Label`s and other features is done using `if` statements (only one `if` actually, but still). A separate control for modifying labels would suit better in my opinion, maybe extending the current `modify` control. However, this would imply major refactoring (which I am opened to tackle). 

Also, the default `ol-dialog` could be used for editing the value of the label, but I had trouble adapting the current functionality in the `control` base class to the `Label` control needs. Specifically, the dialog is opened on `control.activate` event by default, whereas in the `Labels` case, it must be opened on start editing event. Another reason why a separate `modify` control for labels might suit better. 