### PR TITLE
onMapClick option

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ole",
-  "version": "1.1.6",
+  "version": "1.1.7-beta.1",
   "description": "OpenLayers Editor",
   "scripts": {
     "build": "neutrino build",

--- a/src/control/modify.js
+++ b/src/control/modify.js
@@ -111,6 +111,8 @@ class ModifyControl extends Control {
    * @param {function} [options.deleteCondition=backspace key || delete key]
    * Function that takes a browser keyboard event, should return true to delete selected features.
    * @param {ol.events.condition} [options.deleteNodeCondition=click] {@link https://openlayers.org/en/latest/apidoc/module-ol_events_condition.html|openlayers condition} to delete a node when modifying a feature.
+   * @param {function} [options.onMapClick=Clears feature selection]
+   * Function that takes a {@link https://openlayers.org/en/latest/apidoc/module-ol_MapBrowserEvent-MapBrowserEvent.html|openlayers MapBrowserEvent} (click) and the ModifyControl iteself as arguments.
    */
   constructor(options) {
     super(Object.assign(
@@ -172,6 +174,8 @@ class ModifyControl extends Control {
     });
 
     this.getFeatureFilter = options.getFeatureFilter || (() => true);
+
+    this.onMapClick = options.onMapClick;
 
     this.getFeatureAtPixel = (pixel) => {
       const feature = (this.map.getFeaturesAtPixel(pixel, {
@@ -331,8 +335,15 @@ class ModifyControl extends Control {
      * @private
      */
 
+    const defaultModifyCondition = (evt) => {
+      /* Only double click select when no features present, otherwise zoom map */
+      if (evt.type==='dblclick') {
+        return this.map.hasFeatureAtPixel(evt.pixel)
+      }
+    };
+
     this.selectModify = new Select({
-      condition: options.modifyCondition || doubleClick,
+      condition: options.modifyCondition || ((evt) => defaultModifyCondition(evt)),
       toggleCondition: options.modifyToggleCondition || shiftKeyOnly,
       filter: this.selectFilter,
       style: this.selectModifyStyle,
@@ -575,6 +586,14 @@ class ModifyControl extends Control {
     }
 
     if (!this.map.hasFeatureAtPixel(evt.pixel)) {
+      // Apply onMapClick from options if defined
+      if (this.onMapClick) {
+        evt.stopPropagation();
+        evt.preventDefault();
+        this.onMapClick(evt, this);
+        return;
+      }
+      // Default: Clear selection
       interaction.getFeatures().clear();
     }
   }

--- a/src/control/modify.js
+++ b/src/control/modify.js
@@ -5,7 +5,7 @@ import GeometryCollection from 'ol/geom/GeometryCollection';
 import { MultiPoint, Point } from 'ol/geom';
 import GeometryType from 'ol/geom/GeometryType';
 import { Modify, Pointer } from 'ol/interaction';
-import { singleClick, doubleClick, shiftKeyOnly, click } from 'ol/events/condition';
+import { singleClick, shiftKeyOnly, click } from 'ol/events/condition';
 import { Select } from '../interaction';
 import Control from './control';
 import image from '../../img/modify_geometry2.svg';
@@ -335,15 +335,11 @@ class ModifyControl extends Control {
      * @private
      */
 
-    const defaultModifyCondition = (evt) => {
-      /* Only double click select when no features present, otherwise zoom map */
-      if (evt.type==='dblclick') {
-        return this.map.hasFeatureAtPixel(evt.pixel)
-      }
-    };
+    /* Only double click select when no features present, otherwise zoom map */
+    const defaultModifyCondition = evt => evt.type === 'dblclick' && this.map.hasFeatureAtPixel(evt.pixel);
 
     this.selectModify = new Select({
-      condition: options.modifyCondition || ((evt) => defaultModifyCondition(evt)),
+      condition: options.modifyCondition || (evt => defaultModifyCondition(evt)),
       toggleCondition: options.modifyToggleCondition || shiftKeyOnly,
       filter: this.selectFilter,
       style: this.selectModifyStyle,

--- a/src/index.html
+++ b/src/index.html
@@ -119,7 +119,7 @@
       });
 
       var modify = new ole.control.Modify({
-        source: editLayer.getSource()
+        source: editLayer.getSource(),
       });
 
       var buffer = new ole.control.Buffer({


### PR DESCRIPTION
In Tweetaro it should be possible to relocate selected features with a click, but this is currently only possible by hacking/overwriting current proprietary methods (click on map always clears the selection). An Option has been added to override the default behaviour.

Updates:
- Added onMapClick ModifyControl option: Takes a map browser click event and itself  as arguments (itself so the control can be accessed in the newly defined function)
- Fixed issue in https://github.com/geops/openlayers-editor/issues/183 (double click zoom vs double click modifyCondition)

Test version [1.1.7-beta.1](https://www.npmjs.com/package/ole/v/1.1.7-beta.1) published & tested in Tweetaro dev instance https://railview.dev.geops.io/tweets/ and locally in trafimage-cartaro