### PR TITLE
Fix delete node bug

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ole",
-  "version": "1.1.7",
+  "version": "1.1.8-beta.1",
   "description": "OpenLayers Editor",
   "scripts": {
     "build": "neutrino build",

--- a/src/interaction/select.js
+++ b/src/interaction/select.js
@@ -411,7 +411,7 @@ function handleEvent(mapBrowserEvent) {
          * @return {boolean|undefined} Continue to iterate over the features.
          */
         function(feature, layer) {
-          if (this.filter_(feature, layer) && layer) {
+          if (layer && this.filter_(feature, layer)) {
             if ((add || toggle) && !includes(features.getArray(), feature)) {
               selected.push(feature);
               this.addFeatureLayerAssociation_(feature, layer);

--- a/src/interaction/select.js
+++ b/src/interaction/select.js
@@ -378,7 +378,7 @@ function handleEvent(mapBrowserEvent) {
           /* If feature layer is null, omit the selection.
            * Prevents mistakenly selecting features from the overlay.
            */
-          if (this.filter_(feature, layer) && layer) {
+          if (layer && this.filter_(feature, layer)) {
             selected.push(feature);
             this.addFeatureLayerAssociation_(feature, layer);
             return !this.multi_;

--- a/src/interaction/select.js
+++ b/src/interaction/select.js
@@ -375,7 +375,10 @@ function handleEvent(mapBrowserEvent) {
          * @return {boolean|undefined} Continue to iterate over the features.
          */
         function(feature, layer) {
-          if (this.filter_(feature, layer)) {
+          /* If feature layer is null, omit the selection.
+           * Prevents mistakenly selecting features from the overlay.
+           */
+          if (this.filter_(feature, layer) && layer) {
             selected.push(feature);
             this.addFeatureLayerAssociation_(feature, layer);
             return !this.multi_;
@@ -408,7 +411,7 @@ function handleEvent(mapBrowserEvent) {
          * @return {boolean|undefined} Continue to iterate over the features.
          */
         function(feature, layer) {
-          if (this.filter_(feature, layer)) {
+          if (this.filter_(feature, layer) && layer) {
             if ((add || toggle) && !includes(features.getArray(), feature)) {
               selected.push(feature);
               this.addFeatureLayerAssociation_(feature, layer);


### PR DESCRIPTION
Adressing issue https://github.com/geops/openlayers-editor/issues/186#issue-716621571

Node clicks now omit event if node can't be deleted.

Tested in mapset Plan-Editor with https://www.npmjs.com/package/ole/v/1.1.8-beta.1

Test in https://deploy-preview-191--openlayers-editor.netlify.app/