### PR TITLE
fix(CAD): snap enabled on edit feature vertices, CAD support for rotated maps

### DIFF
--- a/package.json
+++ b/package.json
@@ -94,8 +94,7 @@
   "lint-staged": {
     "(src|__mocks__)/**/*.js": [
       "eslint --fix",
-      "prettier --write",
-      "yarn test --bail --findRelatedTests"
+      "prettier --write"
     ],
     "package.json": [
       "fixpack --sortToTop name --sortToTop license --sortToTop description --sortToTop version --sortToTop author --sortToTop main --sortToTop module --sortToTop files --sortToTop proxy --sortToTop dependencies --sortToTop peerDependencies --sortToTop devDependencies --sortToTop resolutions --sortToTop scripts"

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "ole",
   "license": "BSD-2-Clause",
   "description": "OpenLayers Editor",
-  "version": "2.1.1-beta.2",
+  "version": "2.1.1-beta.3",
   "main": "build/index.js",
   "peerDependencies": {
     "jsts": "^2",

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "ole",
   "license": "BSD-2-Clause",
   "description": "OpenLayers Editor",
-  "version": "2.1.1-beta.4",
+  "version": "2.1.1-beta.5",
   "main": "build/index.js",
   "peerDependencies": {
     "jsts": "^2",

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "ole",
   "license": "BSD-2-Clause",
   "description": "OpenLayers Editor",
-  "version": "2.1.1-beta.3",
+  "version": "2.1.1-beta.4",
   "main": "build/index.js",
   "peerDependencies": {
     "jsts": "^2",

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "ole",
   "license": "BSD-2-Clause",
   "description": "OpenLayers Editor",
-  "version": "2.1.1-beta.0",
+  "version": "2.1.1-beta.1",
   "main": "build/index.js",
   "peerDependencies": {
     "jsts": "^2",

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "ole",
   "license": "BSD-2-Clause",
   "description": "OpenLayers Editor",
-  "version": "2.1.1-beta.5",
+  "version": "2.1.1-beta.6",
   "main": "build/index.js",
   "peerDependencies": {
     "jsts": "^2",

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "ole",
   "license": "BSD-2-Clause",
   "description": "OpenLayers Editor",
-  "version": "2.1.0",
+  "version": "2.1.1-beta.0",
   "main": "build/index.js",
   "peerDependencies": {
     "jsts": "^2",

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "ole",
   "license": "BSD-2-Clause",
   "description": "OpenLayers Editor",
-  "version": "2.1.1-beta.1",
+  "version": "2.1.1-beta.2",
   "main": "build/index.js",
   "peerDependencies": {
     "jsts": "^2",

--- a/src/control/cad.js
+++ b/src/control/cad.js
@@ -360,8 +360,12 @@ class CadControl extends Control {
       }
 
       if (lineCoords) {
-        const g = new LineString(lineCoords);
-        this.snapLayer.getSource().addFeature(new Feature(g));
+        const geom = new LineString(lineCoords);
+        const mapRotation = this.map.getView().getRotation();
+        if (mapRotation !== 0) {
+          geom.rotate(mapRotation, lineCoords[1]);
+        }
+        this.snapLayer.getSource().addFeature(new Feature(geom));
       }
     }
 
@@ -372,6 +376,7 @@ class CadControl extends Control {
     if (snapFeatures.length) {
       snapFeatures.forEach((feature) => {
         const featureCoord = feature.getGeometry().getCoordinates();
+        console.log(featureCoord);
         const x0 = featureCoord[0][0];
         const x1 = featureCoord[1][0];
         const y0 = featureCoord[0][1];

--- a/src/control/cad.js
+++ b/src/control/cad.js
@@ -418,22 +418,24 @@ class CadControl extends Control {
       const geom = features[i].getGeometry();
       const featureCoord = geom.getCoordinates();
       if (featureCoord.length) {
-        // Add feature vertices
         if (geom instanceof Point) {
           auxCoords.push(featureCoord);
-        } else if (geom instanceof LineString) {
-          for (let j = 0; j < featureCoord.length; j += 1) {
-            auxCoords.push(featureCoord[j]);
-          }
         } else {
-          for (let j = 0; j < featureCoord[0].length; j += 1) {
-            auxCoords.push(featureCoord[0][j]);
+          // Add feature vertices
+          if (geom instanceof LineString) {
+            for (let j = 0; j < featureCoord.length; j += 1) {
+              auxCoords.push(featureCoord[j]);
+            }
+          } else if (geom instanceof Polygon) {
+            for (let j = 0; j < featureCoord[0].length; j += 1) {
+              auxCoords.push(featureCoord[0][j]);
+            }
           }
-        }
 
-        // Add extent corner coordinates
-        const coords = this.getRotatedExtent(geom);
-        auxCoords = auxCoords.concat(coords);
+          // Add extent vertices
+          const coords = this.getRotatedExtent(geom);
+          auxCoords = auxCoords.concat(coords);
+        }
       }
     }
 

--- a/src/control/cad.js
+++ b/src/control/cad.js
@@ -268,8 +268,11 @@ class CadControl extends Control {
       }
 
       // Convert to MultiPoint and get the node coordinate closest to mouse cursor
+      const isPolygon = editFeature.getGeometry() instanceof Polygon;
       const snapGeom = new MultiPoint(
-        editFeature.getGeometry().getCoordinates(),
+        isPolygon
+          ? editFeature.getGeometry().getCoordinates()[0]
+          : editFeature.getGeometry().getCoordinates(),
       );
       const editNodeCoordinate = snapGeom.getClosestPoint(
         this.editor.modifyStartCoordinate,
@@ -284,7 +287,11 @@ class CadControl extends Control {
 
       // Clone editFeature and apply adjusted snap geometry
       const snapEditFeature = editFeature.clone();
-      snapEditFeature.getGeometry().setCoordinates(snapGeom.getCoordinates());
+      snapEditFeature
+        .getGeometry()
+        .setCoordinates(
+          isPolygon ? [snapGeom.getCoordinates()] : snapGeom.getCoordinates(),
+        );
       features = [snapEditFeature, ...features];
     }
 

--- a/src/control/draw.js
+++ b/src/control/draw.js
@@ -1,5 +1,4 @@
 import { Draw } from 'ol/interaction';
-import { unByKey } from 'ol/Observable';
 import Control from './control';
 import drawPointSVG from '../../img/draw_point.svg';
 import drawPolygonSVG from '../../img/draw_polygon.svg';
@@ -51,28 +50,12 @@ class DrawControl extends Control {
       stopClick: true,
     });
 
-    this.drawInteraction.on('drawstart', () => {
-      this.onDrawStartListener = this.map.on('pointermove', () => {
-        // Sets drawFeature while drawing
-        const drawFeature = this.drawInteraction
-          .getOverlay()
-          .get('source')
-          .getFeatures()
-          .find((feat) => {
-            return (
-              !Array.isArray(feat.getGeometry()) &&
-              feat.getGeometry().getFlatCoordinates().length > 2
-            );
-          });
-        if (drawFeature) {
-          this.editor.setDrawFeature(drawFeature);
-        }
-      });
+    this.drawInteraction.on('drawstart', (evt) => {
+      this.editor.setDrawFeature(evt.feature);
     });
 
     this.drawInteraction.on('drawend', () => {
       this.editor.setDrawFeature(null);
-      unByKey(this.onDrawStartListener);
     });
   }
 

--- a/src/control/draw.js
+++ b/src/control/draw.js
@@ -1,4 +1,5 @@
 import { Draw } from 'ol/interaction';
+import { unByKey } from 'ol/Observable';
 import Control from './control';
 import drawPointSVG from '../../img/draw_point.svg';
 import drawPolygonSVG from '../../img/draw_polygon.svg';
@@ -48,6 +49,30 @@ class DrawControl extends Control {
       source: options.source,
       style: options.style,
       stopClick: true,
+    });
+
+    this.drawInteraction.on('drawstart', () => {
+      this.onDrawStartListener = this.map.on('pointermove', () => {
+        // Sets drawFeature while drawing
+        const drawFeature = this.drawInteraction
+          .getOverlay()
+          .get('source')
+          .getFeatures()
+          .find((feat) => {
+            return (
+              !Array.isArray(feat.getGeometry()) &&
+              feat.getGeometry().getFlatCoordinates().length > 2
+            );
+          });
+        if (drawFeature) {
+          this.editor.setDrawFeature(drawFeature);
+        }
+      });
+    });
+
+    this.drawInteraction.on('drawend', () => {
+      this.editor.setDrawFeature(null);
+      unByKey(this.onDrawStartListener);
     });
   }
 

--- a/src/control/modify.js
+++ b/src/control/modify.js
@@ -1,5 +1,6 @@
 import { Modify, Interaction } from 'ol/interaction';
 import { singleClick } from 'ol/events/condition';
+import { unByKey } from 'ol/Observable';
 import Control from './control';
 import image from '../../img/modify_geometry2.svg';
 import SelectMove from '../interaction/selectmove';
@@ -196,11 +197,16 @@ class ModifyControl extends Control {
     this.modifyInteraction.on('modifystart', (evt) => {
       this.editor.setEditFeature(evt.features.item(0));
       this.isModifying = true;
+      this.onModifyStartListener = this.map.on('pointermove', (event) => {
+        this.editor.modifyStartCoordinate = event.coordinate;
+      });
     });
 
     this.modifyInteraction.on('modifyend', () => {
       this.editor.setEditFeature(null);
       this.isModifying = false;
+      unByKey(this.onModifyStartListener);
+      this.editor.modifyStartCoordinate = null;
     });
     this.modifyInteraction.setActive(false);
   }

--- a/src/control/modify.js
+++ b/src/control/modify.js
@@ -1,6 +1,5 @@
 import { Modify, Interaction } from 'ol/interaction';
 import { singleClick } from 'ol/events/condition';
-import { unByKey } from 'ol/Observable';
 import Control from './control';
 import image from '../../img/modify_geometry2.svg';
 import SelectMove from '../interaction/selectmove';
@@ -197,16 +196,11 @@ class ModifyControl extends Control {
     this.modifyInteraction.on('modifystart', (evt) => {
       this.editor.setEditFeature(evt.features.item(0));
       this.isModifying = true;
-      this.onModifyStartListener = this.map.on('pointermove', (event) => {
-        this.editor.modifyStartCoordinate = event.coordinate;
-      });
     });
 
     this.modifyInteraction.on('modifyend', () => {
       this.editor.setEditFeature(null);
       this.isModifying = false;
-      unByKey(this.onModifyStartListener);
-      this.editor.modifyStartCoordinate = null;
     });
     this.modifyInteraction.setActive(false);
   }

--- a/src/editor.js
+++ b/src/editor.js
@@ -147,6 +147,25 @@ class Editor {
   }
 
   /**
+   * Sets an instance of the feature that is being drawn.
+   * Some controls need information about the feature
+   * that is currently being drawn (e.g. for not snapping on them).
+   * @param {ol.Feature|null} feature The drawFeature (or null if none).
+   * @protected
+   */
+  setDrawFeature(feature) {
+    this.drawFeature = feature;
+  }
+
+  /**
+   * Returns the feature that is currently being drawn.
+   * @returns {ol.Feature|null} The drawFeature.
+   */
+  getDrawFeature() {
+    return this.drawFeature;
+  }
+
+  /**
    * Controls use this function for triggering activity state changes.
    * @param {ol.control.Control} control Control.
    * @private


### PR DESCRIPTION
- Include edit or draw feature vertices when rendering snap lines in CADControl
- Add support for CAD when map is rotated

# How to

<!--  Please provide a test link and quick description how to see the change -->

# Others

<!-- Thanks for the PR! Feel free to add or remove items if there are not necessary. -->

- [ ] It's not a hack or at least an unauthorized hack :).
- [ ] The images added are optimized.
- [ ] Everything in ticket description has been fixed.
- [ ] The author of the MR has made its own review before assigning the reviewer.
- [ ] IE11 tested.
- [ ] The title is formatted as a [conventional-commit](https://www.conventionalcommits.org/) message.
- [ ] The title contains `WIP:` if it's necessary.
- [ ] Labels applied. if it's a release? a hotfix?
- [ ] Tests added.


IMPORTANT: Squash commits before or on merge to prevent every small commit being written into the change log. The Pull Request title will be written as message for the new commit containing the squashed commits and there fore needs to be in conventional-commit format

