### PR TITLE
feat: add optional move event handler for cad

### DIFF
--- a/src/control/cad.js
+++ b/src/control/cad.js
@@ -33,6 +33,8 @@ class CadControl extends Control {
   /**
    * @param {Object} [options] Tool options.
    * @param {Function} [options.drawCustomSnapLines] Allow to draw more snapping lines using selected corrdinaites.
+   * @param {Function} [options.handleMoveEvent] A function passed to determine whether to apply snap hints
+   *   on a pointer move event (all pointer events handled by default)
    * @param {Function} [options.filter] Returns an array containing the features
    *   to include for CAD (takes the source as a single argument).
    * @param {Number} [options.nbClosestFeatures] Number of features to use for snapping (closest first). Default is 5.
@@ -146,6 +148,13 @@ class CadControl extends Control {
     this.filter = options.filter || null;
 
     /**
+     * Determines whether to handle a pointer event
+     * @type {Function}
+     * @private
+     */
+    this.handleMoveEvent = options.handleMoveEvent || null;
+
+    /**
      * Interaction for snapping
      * @type {ol.interaction.Snap}
      * @private
@@ -220,6 +229,13 @@ class CadControl extends Control {
    * @param {ol.MapBrowserEvent} evt Move event.
    */
   onMove(evt) {
+    if (
+      typeof this.handleMoveEvent === 'function' &&
+      !this.handleMoveEvent(evt)
+    ) {
+      return;
+    }
+
     const features = this.getClosestFeatures(
       evt.coordinate,
       this.nbClosestFeatures,

--- a/src/control/cad.js
+++ b/src/control/cad.js
@@ -229,6 +229,9 @@ class CadControl extends Control {
    * @param {ol.MapBrowserEvent} evt Move event.
    */
   onMove(evt) {
+    this.linesLayer.getSource().clear();
+    this.snapLayer.getSource().clear();
+
     if (
       typeof this.handleMoveEvent === 'function' &&
       !this.handleMoveEvent(evt)
@@ -240,9 +243,6 @@ class CadControl extends Control {
       evt.coordinate,
       this.nbClosestFeatures,
     );
-
-    this.linesLayer.getSource().clear();
-    this.snapLayer.getSource().clear();
 
     this.pointerInteraction.dispatchEvent(
       new SnapEvent(SnapEventType.SNAP, features.length ? features : null, evt),


### PR DESCRIPTION
For the cad control a new option is exposed to allow the user to selectively handle move events and prevent lines from being drawn in certain cases. In our use case we use this to avoid showing snap guides when there is no feature currently being edited or drawn. Our use case does not use the controls bar and several custom interactions so we needed a way to decide if snapping should be actively shown based on the active move event.

# Others

<!-- Thanks for the PR! Feel free to add or remove items if there are not necessary. -->

- [x] It's not a hack or at least an unauthorized hack :).
- [x] Everything in ticket description has been fixed.
- [x] The author of the MR has made its own review before assigning the reviewer.
- [x] The title is formatted as a [conventional-commit](https://www.conventionalcommits.org/) message.


IMPORTANT: Squash commits before or on merge to prevent every small commit being written into the change log. The Pull Request title will be written as message for the new commit containing the squashed commits and there fore needs to be in conventional-commit format

