### PR TITLE
fix: cleanup map events unmounting cad control

### DIFF
--- a/src/control/cad.js
+++ b/src/control/cad.js
@@ -188,30 +188,34 @@ class CadControl extends Control {
     `;
   }
 
+  handleInteractionAdd = (e) => {
+    const pos = e.target.getArray().indexOf(this.snapInteraction);
+
+    if (
+      this.snapInteraction.getActive() &&
+      pos > -1 &&
+      pos !== e.target.getLength() - 1
+    ) {
+      this.deactivate(true);
+      this.activate(true);
+    }
+  };
+
   /**
    * @inheritdoc
    */
   setMap(map) {
+    if (this.map) {
+      this.map.getInteractions().un('add', this.handleInteractionAdd);
+    }
+
     super.setMap(map);
 
     // Ensure that the snap interaction is at the last position
     // as it must be the first to handle the  pointermove event.
-    this.map.getInteractions().on(
-      'add',
-      ((e) => {
-        const pos = e.target.getArray().indexOf(this.snapInteraction);
-
-        if (
-          this.snapInteraction.getActive() &&
-          pos > -1 &&
-          pos !== e.target.getLength() - 1
-        ) {
-          this.deactivate(true);
-          this.activate(true);
-        }
-        // eslint-disable-next-line no-extra-bind
-      }).bind(this),
-    );
+    if (this.map) {
+      this.map.getInteractions().on('add', this.handleInteractionAdd);
+    }
   }
 
   /**


### PR DESCRIPTION
When unmounting the cad control from the map the events it binds to the map interaction collection should be also disabled

# Others

<!-- Thanks for the PR! Feel free to add or remove items if there are not necessary. -->

- [x] It's not a hack or at least an unauthorized hack :).
- [x] Everything in ticket description has been fixed.
- [x] The author of the MR has made its own review before assigning the reviewer.
- [x] The title is formatted as a [conventional-commit](https://www.conventionalcommits.org/) message.

IMPORTANT: Squash commits before or on merge to prevent every small commit being written into the change log. The Pull Request title will be written as message for the new commit containing the squashed commits and there fore needs to be in conventional-commit format

