### PR TITLE
feat: add line filter for reducing line clutter

### DIFF
--- a/src/control/cad.js
+++ b/src/control/cad.js
@@ -35,6 +35,8 @@ class CadControl extends Control {
    * @param {Function} [options.drawCustomSnapLines] Allow to draw more snapping lines using selected corrdinaites.
    * @param {Function} [options.filter] Returns an array containing the features
    *   to include for CAD (takes the source as a single argument).
+   * @param {Function} [options.lineFilter] An optional filter for the generated snapping lines
+   *   array (takes the lines and cursor coordinate as arguments and returns the new line array)
    * @param {Number} [options.nbClosestFeatures] Number of features to use for snapping (closest first). Default is 5.
    * @param {Number} [options.snapTolerance] Snap tolerance in pixel
    *   for snap lines. Default is 10.
@@ -144,6 +146,11 @@ class CadControl extends Control {
      * @private
      */
     this.filter = options.filter || null;
+
+    /**
+     * Filter the generated line list
+     */
+    this.lineFilter = options.lineFilter || null;
 
     /**
      * Interaction for snapping
@@ -657,7 +664,7 @@ class CadControl extends Control {
       snapLinesOrder,
     } = this.properties;
 
-    const lines = [];
+    let lines = [];
     const helpLinesOrdered = [];
     const helpLines = {
       [ORTHO_LINE_KEY]: [],
@@ -706,6 +713,10 @@ class CadControl extends Control {
         lines.push(lineA);
       }
     });
+
+    if (typeof this.lineFilter === 'function') {
+      lines = this.lineFilter(lines, coordinate);
+    }
 
     // We snap on intersections of lines (distance < this.snapTolerance) or on all the help lines.
     const intersectFeatures = getIntersectedLinesAndPoint(


### PR DESCRIPTION
We added a `lineFilter` option to the `cad` control in order to provide users with a mechanism of removing lines at their discretion.  We use this in our application to remove lines which share a very similar slope and origin in order to reduce guide clutter.

# Others

<!-- Thanks for the PR! Feel free to add or remove items if there are not necessary. -->

- [x] It's not a hack or at least an unauthorized hack :).
- [x] Everything in ticket description has been fixed.
- [x] The author of the MR has made its own review before assigning the reviewer.
- [x] The title is formatted as a [conventional-commit](https://www.conventionalcommits.org/) message.
- [ ] Tests added.


IMPORTANT: Squash commits before or on merge to prevent every small commit being written into the change log. The Pull Request title will be written as message for the new commit containing the squashed commits and there fore needs to be in conventional-commit format

