### PR TITLE
feat: add editor#removeControl

### DIFF
--- a/src/editor.js
+++ b/src/editor.js
@@ -69,11 +69,23 @@ class Editor {
     control.setMap(this.map);
     control.setEditor(this);
 
-    control.addEventListener('change:active', (e) => {
-      this.activeStateChange(e.detail.control);
-    });
+    control.addEventListener('change:active', this.activeStateChange);
 
     this.controls.push(control);
+  }
+
+  /**
+   * Remove a control from the editor
+   * @param {ole.Control} control The control.
+   */
+  removeControl(control) {
+    control.deactivate(true);
+    control.setMap(null);
+    control.setEditor(null);
+    control.removeEventListener('change:active', this.activeStateChange);
+
+    this.controls.remove(control);
+    this.activeControls.remove(control);
   }
 
   /**
@@ -170,7 +182,8 @@ class Editor {
    * @param {ol.control.Control} control Control.
    * @private
    */
-  activeStateChange(ctrl) {
+  activeStateChange = (e) => {
+    const ctrl = e.detail.control;
     // Deactivate other controls that are not standalone
     if (ctrl.getActive() && ctrl.standalone) {
       for (let i = 0; i < this.controls.getLength(); i += 1) {
@@ -191,7 +204,7 @@ class Editor {
     } else {
       this.activeControls.remove(ctrl);
     }
-  }
+  };
 }
 
 export default Editor;


### PR DESCRIPTION
Add `editor#removeControl` as an inverse to `#addControl`. This method will remove the control from the editor and map; it will also unregister all the events that will have been subscribed to.

# Others

<!-- Thanks for the PR! Feel free to add or remove items if there are not necessary. -->

- [x] It's not a hack or at least an unauthorized hack :).
- [x] Everything in ticket description has been fixed.
- [x] The author of the MR has made its own review before assigning the reviewer.
- [x] The title is formatted as a [conventional-commit](https://www.conventionalcommits.org/) message.
- [ ] Tests added.


IMPORTANT: Squash commits before or on merge to prevent every small commit being written into the change log. The Pull Request title will be written as message for the new commit containing the squashed commits and there fore needs to be in conventional-commit format

