### PR TITLE
fix!: limit snappable features to current view extent

### DIFF
--- a/src/control/cad.js
+++ b/src/control/cad.js
@@ -251,7 +251,7 @@ class CadControl extends Control {
    */
   getClosestFeatures(coordinate, numFeatures) {
     const num = numFeatures || 1;
-    const ext = [-Infinity, -Infinity, Infinity, Infinity];
+    const ext = this.map.getView().calculateExtent();
     const featureDict = {};
 
     const pushSnapFeatures = (f) => {


### PR DESCRIPTION
# Purpose

- Avoids confusing guides being generated from features outside of the view. Users of our app at least found this confusing as they would not know what they were snapping to
- Can significantly improves performance on maps with many features as many features can be excluded by the r tree

I can make this an option if preferred.

# Others

<!-- Thanks for the PR! Feel free to add or remove items if there are not necessary. -->

- [x] It's not a hack or at least an unauthorized hack :).
- [x] Everything in ticket description has been fixed.
- [x] The author of the MR has made its own review before assigning the reviewer.
- [x] The title is formatted as a [conventional-commit](https://www.conventionalcommits.org/) message.


